### PR TITLE
Fix compile failure on macOS

### DIFF
--- a/src/info.c
+++ b/src/info.c
@@ -492,7 +492,7 @@ void host() {           // prints the current host machine
 
 // bios
 #ifdef __APPLE__
-void packages() {
+void bios() {
     char format[100];
     snprintf(format, 100, "%s%s", config.bios_label, config.dash);
     if(config.align_infos) printf("%-16s\e[0m", format);

--- a/src/main.c
+++ b/src/main.c
@@ -421,8 +421,8 @@ int main(const int argc, const char **argv) {
                 }
             logo = (char**)logos[0];
 
-            logo_found: ;
         #endif
+        logo_found: ;
     }
     if(!(*config.color))
         strcpy(config.color, logo[1]);


### PR DESCRIPTION
## errors patched:

```
src/info.c:495:6: error: redefinition of 'packages'
void packages() {
     ^
src/info.c:320:6: note: previous definition is here
void packages() {
     ^
1 error generated.
make: *** [info.o] Error 1
```

```
src/main.c:398:18: error: use of undeclared label 'logo_found'
            goto logo_found;
                 ^
1 error generated.
make: *** [main.o] Error 1
```

macOS 12.4 (Intel)