### PR TITLE
macos_infos.c: fix for i386 and ppc

### DIFF
--- a/src/macos_infos.c
+++ b/src/macos_infos.c
@@ -17,6 +17,22 @@ static vm_size_t page_size(mach_port_t host) {
  * Original source: 
  * https://opensource.apple.com/source/system_cmds/system_cmds-496/vm_stat.tproj/vm_stat.c.auto.html
  */
+#if defined(__i386__) || defined(__ppc__)
+static int get_stats(struct vm_statistics *stat, mach_port_t host) {
+    int error;
+
+    unsigned count = HOST_VM_INFO_COUNT; 
+    error = host_statistics(host, 
+                            HOST_VM_INFO,
+                            (host_info_t) stat,
+                            &count);
+
+    if(error != KERN_SUCCESS)
+        return error;
+
+    return 0;
+}
+#else
 static int get_stats(struct vm_statistics64 *stat, mach_port_t host) {
     int error;
 
@@ -31,6 +47,7 @@ static int get_stats(struct vm_statistics64 *stat, mach_port_t host) {
 
     return 0;
 }
+#endif
 
 /* EXPORTS */ 
 
@@ -49,6 +66,20 @@ bytes_t system_mem_size(void) {
 }
 
 bytes_t used_mem_size(void) {
+#if defined(__i386__) || defined(__ppc__)
+    pages_t active, wired, inactive;
+    mach_port_t host = mach_host_self();
+
+    struct vm_statistics vm_stat;
+    if(get_stats(&vm_stat, host) < 0)
+        return 0;
+
+    active   = vm_stat.active_count;
+    wired    = vm_stat.wire_count;
+    inactive = vm_stat.inactive_count;
+
+    return (active + wired + inactive) * page_size(host);
+#else
     pages_t internal, wired, compressed;
     mach_port_t host = mach_host_self();
 
@@ -61,4 +92,5 @@ bytes_t used_mem_size(void) {
     compressed = vm_stat.compressor_page_count;
 
     return (internal + wired + compressed) * page_size(host);
+#endif
 }


### PR DESCRIPTION
P. S. Looks like 32-bit version of the struct has [different fields](https://developer.apple.com/documentation/kernel/vm_statistics_data_t), so we cannot use the identical code.