### PR TITLE
macos_infos: compatibility fix for macOS < 10.9

### DIFF
--- a/src/macos_infos.c
+++ b/src/macos_infos.c
@@ -66,7 +66,7 @@ bytes_t system_mem_size(void) {
 }
 
 bytes_t used_mem_size(void) {
-#if defined(__i386__) || defined(__ppc__)
+#if MAC_OS_X_VERSION_MIN_REQUIRED < 1090
     pages_t active, wired, inactive;
     mach_port_t host = mach_host_self();
 

--- a/src/macos_infos.h
+++ b/src/macos_infos.h
@@ -9,6 +9,7 @@
 
 #include <mach/mach.h>
 #include <stdint.h>
+#include <AvailabilityMacros.h>
 
 #include "bsdwrap.h"
 


### PR DESCRIPTION
Discussed in https://github.com/macports/macports-ports/pull/24809.
Code has already been added to the application for compatibility with retro computing PowerPC Macs, but it was discovered that compressed memory support was only added to the kernel/SDK [starting with Mavericks](https://github.com/search?q=repo%3Aphracker%2FMacOSX-SDKs%20compressor_page_count&type=code).