### PR TITLE
macos_infos: re-fix fallback macros

### DIFF
--- a/src/macos_infos.c
+++ b/src/macos_infos.c
@@ -17,7 +17,7 @@ static vm_size_t page_size(mach_port_t host) {
  * Original source: 
  * https://opensource.apple.com/source/system_cmds/system_cmds-496/vm_stat.tproj/vm_stat.c.auto.html
  */
-#if defined(__i386__) || defined(__ppc__)
+#if MAC_OS_X_VERSION_MIN_REQUIRED < 1090
 static int get_stats(struct vm_statistics *stat, mach_port_t host) {
     int error;
 


### PR DESCRIPTION
We're already using AvailabilityMacros.h, so we'll apply the macro to this part of the code (I thought the previous PR was sufficient).