### PR TITLE
Makefile: do not hardcode prefix on macOS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,7 @@ endif
 ifeq ($(OS),Darwin)
 	INSTALLFLAGS := -m755
 	CONFIGFLAGS := -m644
+	INSTALLPATH := $(PREFIX)/bin
 	CONFIGPATH := ~/.config/
 
 	MACOS_INFOS_H := src/macos_infos.h


### PR DESCRIPTION
Installing anything in `/usr` should rather be avoided on macOS, and in any case there is no need to hardcode that.